### PR TITLE
get a correct eltype for iterators

### DIFF
--- a/src/enumerable/enumerable_groupby.jl
+++ b/src/enumerable/enumerable_groupby.jl
@@ -21,7 +21,7 @@ Base.eltype{T,TKey,TS,SO,ES}(iter::Type{EnumerableGroupBySimple{T,TKey,TS,SO,ES}
 
 function group_by(source::Enumerable, f_elementSelector::Function, elementSelector::Expr)
     TS = eltype(source)
-    TKey = Base.return_types(f_elementSelector, (TS,))[1]
+    TKey = Base._return_type(f_elementSelector, Tuple{TS,})
 
     SO = typeof(source)
 
@@ -69,11 +69,11 @@ Base.eltype{T,TKey,TR,SO,ES}(iter::Type{EnumerableGroupBy{T,TKey,TR,SO,ES}}) = T
 
 function group_by(source::Enumerable, f_elementSelector::Function, elementSelector::Expr, f_resultSelector::Function, resultSelector::Expr)
     TS = eltype(source)
-    TKey = Base.return_types(f_elementSelector, (TS,))[1]
+    TKey = Base._return_type(f_elementSelector, Tuple{TS,})
 
     SO = typeof(source)
 
-    TR = Base.return_types(f_resultSelector, (TS,))[1]
+    TR = Base._return_type(f_resultSelector, Tuple{TS,})
 
     T = Grouping{TKey,TR}
 

--- a/src/enumerable/enumerable_groupjoin.jl
+++ b/src/enumerable/enumerable_groupjoin.jl
@@ -13,8 +13,8 @@ Base.eltype{T,TKeyOuter,TI,SO,SI,OKS,IKS,RS}(iter::Type{EnumerableGroupJoin{T,TK
 function group_join(outer::Enumerable, inner::Enumerable, f_outerKeySelector::Function, outerKeySelector::Expr, f_innerKeySelector::Function, innerKeySelector::Expr, f_resultSelector::Function, resultSelector::Expr)
     TO = eltype(outer)
     TI = eltype(inner)
-    TKeyOuter = Base.return_types(f_outerKeySelector, (TO,))[1]
-    TKeyInner = Base.return_types(f_innerKeySelector, (TI,))[1]
+    TKeyOuter = Base._return_type(f_outerKeySelector, Tuple{TO,})
+    TKeyInner = Base._return_type(f_innerKeySelector, Tuple{TI,})
 
     if TKeyOuter!=TKeyInner
         error("The keys in the join clause have different types, $TKeyOuter and $TKeyInner.")
@@ -23,7 +23,7 @@ function group_join(outer::Enumerable, inner::Enumerable, f_outerKeySelector::Fu
     SO = typeof(outer)
     SI = typeof(inner)
 
-    T = Base.return_types(f_resultSelector, (TO,Array{TI,1}))[1]
+    T = Base._return_type(f_resultSelector, Tuple{TO,Array{TI,1}})
 
     OKS = typeof(f_outerKeySelector)
     IKS = typeof(f_innerKeySelector)

--- a/src/enumerable/enumerable_join.jl
+++ b/src/enumerable/enumerable_join.jl
@@ -13,8 +13,8 @@ Base.eltype{T,TKeyOuter,TI,SO,SI,OKS,IKS,RS}(iter::Type{EnumerableJoin{T,TKeyOut
 function join(outer::Enumerable, inner::Enumerable, f_outerKeySelector::Function, outerKeySelector::Expr, f_innerKeySelector::Function, innerKeySelector::Expr, f_resultSelector::Function, resultSelector::Expr)
     TO = eltype(outer)
     TI = eltype(inner)
-    TKeyOuter = Base.return_types(f_outerKeySelector, (TO,))[1]
-    TKeyInner = Base.return_types(f_innerKeySelector, (TI,))[1]
+    TKeyOuter = Base._return_type(f_outerKeySelector, Tuple{TO,})
+    TKeyInner = Base._return_type(f_innerKeySelector, Tuple{TI,})
 
     if TKeyOuter!=TKeyInner
         error("The keys in the join clause have different types, $TKeyOuter and $TKeyInner.")
@@ -23,7 +23,7 @@ function join(outer::Enumerable, inner::Enumerable, f_outerKeySelector::Function
     SO = typeof(outer)
     SI = typeof(inner)
 
-    T = Base.return_types(f_resultSelector, (TO,TI))[1]
+    T = Base._return_type(f_resultSelector, Tuple{TO,TI})
 
     OKS = typeof(f_outerKeySelector)
     IKS = typeof(f_innerKeySelector)

--- a/src/enumerable/enumerable_orderby.jl
+++ b/src/enumerable/enumerable_orderby.jl
@@ -14,7 +14,7 @@ Base.length{T,S,KS,TKS}(iter::EnumerableOrderby{T,S,KS,TKS}) = length(iter.sourc
 
 function orderby(source::Enumerable, f::Function, f_expr::Expr)
     T = eltype(source)
-    TKS = Base.return_types(f, (T,))[1]
+    TKS = Base._return_type(f, Tuple{T,})
 
     KS = typeof(f)
 
@@ -23,7 +23,7 @@ end
 
 function orderby_descending(source::Enumerable, f::Function, f_expr::Expr)
     T = eltype(source)
-    TKS = Base.return_types(f, (T,))[1]
+    TKS = Base._return_type(f, Tuple{T,})
 
     KS = typeof(f)
 
@@ -72,14 +72,14 @@ Base.length{T,S,KS,TKS}(iter::EnumerableThenBy{T,S,KS,TKS}) = length(iter.source
 
 function thenby(source::Enumerable, f::Function, f_expr::Expr)
     T = eltype(source)
-    TKS = Base.return_types(f, (T,))[1]
+    TKS = Base._return_type(f, Tuple{T,})
     KS = typeof(f)
     return EnumerableThenBy{T,typeof(source),KS,TKS}(source, f, false)
 end
 
 function thenby_descending(source::Enumerable, f::Function, f_expr::Expr)
     T = eltype(source)
-    TKS = Base.return_types(f, (T,))[1]
+    TKS = Base._return_type(f, Tuple{T,})
     KS = typeof(f)
     return EnumerableThenBy{T,typeof(source),KS,TKS}(source, f, true)
 end

--- a/src/enumerable/enumerable_select.jl
+++ b/src/enumerable/enumerable_select.jl
@@ -13,7 +13,7 @@ Base.length{T,S,Q}(iter::EnumerableSelect{T,S,Q}) = length(iter.source)
 
 function select(source::Enumerable, f::Function, f_expr::Expr)
     TS = eltype(source)
-    T = Base.return_types(f, (TS,))[1]
+    T = Base._return_type(f, Tuple{TS,})
     S = typeof(source)
     Q = typeof(f)
     return EnumerableSelect{T,S,Q}(source, f)

--- a/src/enumerable/enumerable_selectmany.jl
+++ b/src/enumerable/enumerable_selectmany.jl
@@ -47,11 +47,11 @@ function select_many(source::Enumerable, f_collectionSelector::Function, collect
         input_type_collection_selector = typeof(inner_collection)
         TCE = input_type_collection_selector.parameters[1]
     else
-        input_type_collection_selector = Base.return_types(f_collectionSelector, (TS,))[1]
+        input_type_collection_selector = Base._return_type(f_collectionSelector, Tuple{TS,})
         TCE = typeof(input_type_collection_selector)==Union || input_type_collection_selector==Any ? Any : input_type_collection_selector.parameters[1]
     end
 
-    T = Base.return_types(f_resultSelector, (TS,TCE))[1]
+    T = Base._return_type(f_resultSelector, Tuple{TS,TCE})
     SO = typeof(source)
 
     CS = typeof(f_collectionSelector)

--- a/src/queryable/queryable_select.jl
+++ b/src/queryable/queryable_select.jl
@@ -4,6 +4,6 @@ immutable QueryableSelect{T,Provider} <: Queryable{T,Provider}
 end
 
 function select{TS,Provider}(source::Queryable{TS,Provider}, f::Function, f_expr::Expr)
-    T = Base.return_types(f, (TS,))[1]
+    T = Base._return_type(f, Tuple{TS,})
     return QueryableSelect{T,Provider}(source, f_expr)
 end


### PR DESCRIPTION
While I don't recommend calling Core.Inference in user code, it's important to at least call the correct method (inferable and guaranteed to return correct answers) instead of the interactive one.


```
sed -i'' -e 's/Base\.return_types(\(.\+\), (\(.\+\)))\[1\]/Base._return_type(\1, Tuple{\2})/' `find src -name \*.jl`
```