### PR TITLE
Fix `@from`

### DIFF
--- a/src/Query.jl
+++ b/src/Query.jl
@@ -59,7 +59,7 @@ macro from(range::Expr, body::Expr)
 
 	body.args = filter(i->i.head!=:line,body.args)
 
-	insert!(body.args,1,:( @from $(range.args[2]) in $(range.args[3]) ))
+	insert!(body.args, 1, Expr(:macrocall, Symbol("@from"), range))
 
 	translate_query(body)
 


### PR DESCRIPTION
I'm on Julia v0.6 and with `Query.jl`/`DataFrames.jl` masters I'm getting the following error:
```
julia> using DataFrames, Query

julia> df=DataFrame(a=[1,2,3,4,5],b=[:a,:b,:a,:b,:b],c=["a",null,"a","b",null]);

julia> @from i in df begin
       @where i.b == :a
       @collect DataFrame
       end
ERROR: MethodError: no method matching @from(::Expr)
Closest candidates are:
  @from(::Expr, ::Expr) at /home/<>/.julia/v0.6/Query/src/Query.jl:52
Stacktrace:
 [1] macro expansion at ./REPL.jl:97 [inlined]
 [2] (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at ./event.jl:73
```

For my non-expert eyes it looks like the error is caused by `:(@from ...)` trying to parse the expression and execute the macro call, but this is not a proper macro call.
So I've changed the line to avoid parsing and construct the AST directly.
Now it seems to work:
```
julia> @from i in df begin
       @where i.b == :a
       @select {i.a, i.c}
       @collect DataFrame
       end

2×2 DataFrames.DataFrame
│ Row │ a │ c │
├─────┼───┼───┤
│ 1   │ 1 │ a │
│ 2   │ 3 │ a │
```