### PR TITLE
ismacro() and other minor simplifications

### DIFF
--- a/src/Query.jl
+++ b/src/Query.jl
@@ -37,6 +37,7 @@ include("queryable/queryable.jl")
 include("queryable/queryable_select.jl")
 include("queryable/queryable_where.jl")
 
+include("query_utils.jl")
 include("query_translation.jl")
 
 include("sources/source_iterable.jl")

--- a/src/query_utils.jl
+++ b/src/query_utils.jl
@@ -1,0 +1,8 @@
+ismacro(ex, name::Symbol, nargs::Integer=-1) =
+    isa(ex, Expr) && ex.head==:macrocall && ex.args[1]==name &&
+    (nargs == -1 || length(ex.args) == nargs+1)
+ismacro(ex, name::String, nargs::Integer=-1) = ismacro(ex, Symbol(name), nargs)
+
+iscall(ex, name::Symbol, nargs::Integer=-1) =
+    isa(ex, Expr) && ex.head==:call && ex.args[1]==name &&
+    (nargs == -1 || length(ex.args) == nargs+1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,27 @@ end
 
 @testset "Queries" begin
 
+    @testset "Utilities" begin
+        @test !Query.ismacro(Symbol("@from"), "@from")
+        @test !Query.ismacro(:(a == 1), "@from")
+        @test Query.ismacro(:(@from 1), "@from")
+        @test Query.ismacro(:(@from(1)), "@from")
+        @test !Query.ismacro(:(@from 1), "@for")
+        @test !Query.ismacro(:(@from,1), "@from")
+        @test Query.ismacro(:(@from 1 2 3), "@from", 3)
+        @test !Query.ismacro(:(@from 1 2 3 4), "@from", 3)
+        @test !Query.ismacro(:(map(1)), :map)
+
+        @test !Query.iscall(Symbol("@from"), :map)
+        @test !Query.iscall(:(a == 1), :map)
+        @test !Query.iscall(:(@from 1), Symbol("@from"))
+        @test !Query.iscall(:(@from(1)), Symbol("@from"))
+        @test Query.iscall(:(map(1)), :map)
+        @test !Query.iscall(:(map,1), :map)
+        @test Query.iscall(:(map(1,2,3)), :map, 3)
+        @test !Query.iscall(:(map(1,2,3,4)), :map, 3)
+    end
+
 source_df = DataFrame(name=["John", "Sally", "Kirk"], age=[23., 42., 59.], children=[3,5,2])
 
 q = @from i in source_df begin


### PR DESCRIPTION
Just some minor simplifications of the code.
* define and use `ismacro()` for recurring macro expression tests
* same for `iscall()`
* `QueryException` for more structured error reporting during `@from` query macro processing